### PR TITLE
collision spaces

### DIFF
--- a/Box2D/Box2D/Dynamics/b2Body.h
+++ b/Box2D/Box2D/Dynamics/b2Body.h
@@ -67,6 +67,7 @@ struct b2BodyDef
 		type = b2_staticBody;
 		active = true;
 		gravityScale = 1.0f;
+		space = 0;
 	}
 
 	/// The body type: static, kinematic, or dynamic.
@@ -120,6 +121,8 @@ struct b2BodyDef
 
 	/// Scale the gravity applied to this body.
 	float32 gravityScale;
+
+	int32 space;
 };
 
 /// A rigid body. These are created via b2World::CreateBody.
@@ -360,6 +363,9 @@ public:
 	b2Fixture* GetFixtureList();
 	const b2Fixture* GetFixtureList() const;
 
+	void SetSpace(int32 spaceId);
+	int32 GetSpace() const;
+
 	/// Get the list of all joints attached to this body.
 	b2JointEdge* GetJointList();
 	const b2JointEdge* GetJointList() const;
@@ -453,6 +459,7 @@ private:
 
 	b2Fixture* m_fixtureList;
 	int32 m_fixtureCount;
+	int32 m_fixtureSpace;
 
 	b2JointEdge* m_jointList;
 	b2ContactEdge* m_contactList;
@@ -694,6 +701,11 @@ inline b2Fixture* b2Body::GetFixtureList()
 inline const b2Fixture* b2Body::GetFixtureList() const
 {
 	return m_fixtureList;
+}
+
+inline int32 b2Body::GetSpace() const
+{
+	return m_fixtureSpace;
 }
 
 inline b2JointEdge* b2Body::GetJointList()

--- a/Box2D/Box2D/Dynamics/b2ContactManager.h
+++ b/Box2D/Box2D/Dynamics/b2ContactManager.h
@@ -31,6 +31,11 @@ class b2ContactManager
 {
 public:
 	b2ContactManager();
+	~b2ContactManager();
+
+	void SetSpacesCount(int32 spacesCount);
+	int32 GetSpacesCount() const;
+	b2BroadPhase* GetBroadPhase(int32 spaceId) const;
 
 	// Broad-phase callback.
 	void AddPair(void* proxyUserDataA, void* proxyUserDataB);
@@ -40,13 +45,23 @@ public:
 	void Destroy(b2Contact* c);
 
 	void Collide();
-            
-	b2BroadPhase m_broadPhase;
+	
+	void ShiftOrigin(const b2Vec2& newOrigin);
+
+	int32 GetProxyCount() const;
+	int32 GetTreeHeight() const;
+	int32 GetTreeBalance() const;
+	float32 GetTreeQuality() const;
+
 	b2Contact* m_contactList;
 	int32 m_contactCount;
 	b2ContactFilter* m_contactFilter;
 	b2ContactListener* m_contactListener;
 	b2BlockAllocator* m_allocator;
+	
+protected:
+	b2BroadPhase* m_broadPhases;
+	int32 m_broadPhasesCount;
 };
 
 #endif

--- a/Box2D/Box2D/Dynamics/b2Fixture.cpp
+++ b/Box2D/Box2D/Dynamics/b2Fixture.cpp
@@ -210,7 +210,7 @@ void b2Fixture::Refilter()
 	}
 
 	// Touch each proxy so that new pairs may be created
-	b2BroadPhase* broadPhase = &world->m_contactManager.m_broadPhase;
+	b2BroadPhase* broadPhase = world->m_contactManager.GetBroadPhase(m_body->GetSpace());
 	for (int32 i = 0; i < m_proxyCount; ++i)
 	{
 		broadPhase->TouchProxy(m_proxies[i].proxyId);

--- a/Box2D/Box2D/Dynamics/b2World.h
+++ b/Box2D/Box2D/Dynamics/b2World.h
@@ -111,7 +111,7 @@ public:
 	/// provided AABB.
 	/// @param callback a user implemented callback class.
 	/// @param aabb the query box.
-	void QueryAABB(b2QueryCallback* callback, const b2AABB& aabb) const;
+	void QueryAABB(b2QueryCallback* callback, const b2AABB& aabb, int32 spaceId = 0) const;
 
 	/// Ray-cast the world for all fixtures in the path of the ray. Your callback
 	/// controls whether you get the closest point, any point, or n-points.
@@ -119,7 +119,7 @@ public:
 	/// @param callback a user implemented callback class.
 	/// @param point1 the ray starting point
 	/// @param point2 the ray ending point
-	void RayCast(b2RayCastCallback* callback, const b2Vec2& point1, const b2Vec2& point2) const;
+	void RayCast(b2RayCastCallback* callback, const b2Vec2& point1, const b2Vec2& point2, int32 spaceId = 0) const;
 
 	/// Get the world body list. With the returned body, use b2Body::GetNext to get
 	/// the next body in the world list. A NULL body indicates the end of the list.
@@ -198,6 +198,9 @@ public:
 	/// The body shift formula is: position -= newOrigin
 	/// @param newOrigin the new origin with respect to the old origin
 	void ShiftOrigin(const b2Vec2& newOrigin);
+	
+	void SetSpacesCount(int32 spacesCount);
+	int32 GetSpacesCount() const;
 
 	/// Get the contact manager for testing.
 	const b2ContactManager& GetContactManager() const;
@@ -339,6 +342,15 @@ inline void b2World::SetAutoClearForces(bool flag)
 inline bool b2World::GetAutoClearForces() const
 {
 	return (m_flags & e_clearForces) == e_clearForces;
+}
+
+inline void b2World::SetSpacesCount(int32 spacesCount)
+{
+	m_contactManager.SetSpacesCount(spacesCount);
+}
+inline int32 b2World::GetSpacesCount() const
+{
+	return m_contactManager.GetSpacesCount();
 }
 
 inline const b2ContactManager& b2World::GetContactManager() const

--- a/Box2D/Testbed/Tests/Tiles.h
+++ b/Box2D/Testbed/Tests/Tiles.h
@@ -123,8 +123,8 @@ public:
 	void Step(Settings* settings)
 	{
 		const b2ContactManager& cm = m_world->GetContactManager();
-		int32 height = cm.m_broadPhase.GetTreeHeight();
-		int32 leafCount = cm.m_broadPhase.GetProxyCount();
+		int32 height = cm.GetTreeHeight();
+		int32 leafCount = cm.GetProxyCount();
 		int32 minimumNodeCount = 2 * leafCount - 1;
 		float32 minimumHeight = ceilf(logf(float32(minimumNodeCount)) / logf(2.0f));
 		g_debugDraw.DrawString(5, m_textLine, "dynamic tree height = %d, min = %d", height, int32(minimumHeight));

--- a/Box2D/Testbed/Tests/WrappedWorlds.h
+++ b/Box2D/Testbed/Tests/WrappedWorlds.h
@@ -30,8 +30,8 @@
 /// is totally outside it's space, only copy remains (and becames main body)
 
 /// This feature requires:
-///  - teleport joint - DONE!
-///  - spaces - TODO: right now it's using collision masks
+///  - teleport joint
+///  - spaces
 
 #define OFFSET 40.0f
 
@@ -40,12 +40,15 @@ class WrappedWorlds : public Test
 public:
 	WrappedWorlds()
 	{
+		m_world->SetSpacesCount(2);
+		
 		b2Body* body_sp1 = NULL;
 		b2Body* body_sp2 = NULL;
 
 		// Space 1 ground
 		{
 			b2BodyDef bd;
+			bd.space = 0;
 			b2Body* ground = m_world->CreateBody(&bd);
 
 			b2Vec2 vs[11];
@@ -65,14 +68,13 @@ public:
 			
 			b2FixtureDef def;
 			def.shape = &shape;
-			def.filter.categoryBits = 1;
-			def.filter.maskBits = 1;
 			ground->CreateFixture(&def);
 		}
 		
 		// Space 2 ground
 		{
 			b2BodyDef bd;
+			bd.space = 1;
 			b2Body* ground = m_world->CreateBody(&bd);
 
 			b2Vec2 vs[11];
@@ -92,14 +94,13 @@ public:
 
 			b2FixtureDef def;
 			def.shape = &shape;
-			def.filter.categoryBits = 2;
-			def.filter.maskBits = 2;
 			ground->CreateFixture(&def);
 		}
 		
 		// Space 1 Test body
 		{
 			b2BodyDef bd;
+			bd.space = 0;
 			bd.position.Set(0.0f, 5.0f);
 			bd.type = b2_dynamicBody;
 			body_sp1 = m_world->CreateBody(&bd);
@@ -110,14 +111,13 @@ public:
 			b2FixtureDef def;
 			def.shape = &shape;
 			def.density = 20.0f;
-			def.filter.categoryBits = 1;
-			def.filter.maskBits = 1;
 			body_sp1->CreateFixture(&def);
 		}	
 		
 		// Space 2 Test body
 		{
 			b2BodyDef bd;
+			bd.space = 1;
 			bd.position.Set(0.0f - OFFSET, 5.0f);
 			bd.type = b2_dynamicBody;
 			body_sp2 = m_world->CreateBody(&bd);
@@ -128,8 +128,6 @@ public:
 			b2FixtureDef def;
 			def.shape = &shape;
 			def.density = 20.0f;
-			def.filter.categoryBits = 2;
-			def.filter.maskBits = 2;
 			body_sp2->CreateFixture(&def);
 		}
 		// Teleport joint
@@ -144,11 +142,9 @@ public:
 	void Step(Settings* settings)
 	{
 		Test::Step(settings);
-		g_debugDraw.DrawString(5, m_textLine, "This tests various character collision shapes.");
+		g_debugDraw.DrawString(5, m_textLine, "This tests teleport joint and spaces.");
 		m_textLine += DRAW_STRING_NEW_LINE;
-		g_debugDraw.DrawString(5, m_textLine, "Limitation: square and hexagon can snag on aligned boxes.");
-		m_textLine += DRAW_STRING_NEW_LINE;
-		g_debugDraw.DrawString(5, m_textLine, "Feature: edge chains have smooth collision inside and out.");
+		g_debugDraw.DrawString(5, m_textLine, "Limitation: Only space index 0 is interactable in this demo framework.");
 		m_textLine += DRAW_STRING_NEW_LINE;
 	}
 


### PR DESCRIPTION
Added spaces as a quick way to filter out unrelated simulation layers during collision detection. Bodies in different spaces can still interact using joints.